### PR TITLE
Adjust academics accountability

### DIFF
--- a/Bylaws.tex
+++ b/Bylaws.tex
@@ -150,7 +150,7 @@
 
 \section If a member of the Active Organization misses more than one work day in a month for an unexcused reason, the member will lose the right to attend social events and chapter dinner, until said brother is caught up on work days. Work days can be made up by the House Manager’s approval.
 
-\section If a member of the Active Organization fails to attend a required academics meeting as defined by the Academics chair, they will lose their right to attend social events. The member may have this right restored by attending two consecutive academics meetings.
+\section If a member of the Active Organization fails to attend a required academics meeting as defined by the Academics chair, they will lose their right to attend social events. The member may have this right restored by making up the missed meeting in a manner deemed acceptable by the Academics Chair.
 
 \section If a member of the Active Organization misses more than one-fifth of the recruitment events during a semester for unexcused reasons, they lose the right to have a little brother for that semester.  
 


### PR DESCRIPTION
When restructuring the job of the Academics chair, we also had to restructure how we are holding Brothers accountable. This will allow us to enforce attendance at academics meetings.