### PR TITLE
Add definitions of social and brotherhood events

### DIFF
--- a/Bylaws.tex
+++ b/Bylaws.tex
@@ -47,7 +47,7 @@
 
 \section The Recruitment Chair shall have authority and responsibility in organizing and overseeing all Recruitment related activities. He shall appoint the members of the Recruitment Committee. The accountability report of the Recruitment Chair consists of attendance of each member to every recruitment event.
 
-\section The Social Chair shall have the responsibility of planning major social events, providing brotherhood events, and provide two Greek and two non-Greek social events per year. He is also in charge of communicating and planning with the alumni for Founders’ Day. The accountability report of the Social Chair consists of the attendance of all members at the major social events.
+\section The Social Chair shall have the responsibility of planning major social events, providing brotherhood events, and provide two Greek and two non-Greek social events per year. A social event is defined as any recreational activity planned by a member of the organization and announced at business meeting. A brotherhood event is defined as a social event whose attendance is restricted to members of the organization. He is also in charge of communicating and planning with the alumni for Founders’ Day. The accountability report of the Social Chair consists of the attendance of all members at the major social events.
 
 \section The Philanthropy Chair shall have the responsibility of managing service events, university events, and events within the community. The accountability report of the Philanthropy Chair consists of the records of each member’s fulfillment of the required philanthropy hours.
 


### PR DESCRIPTION
There have been issues in the past with differentiating between social events, brotherhood, events, and other events that don't fall into this category. This amendment is being proposed to help clear that up.